### PR TITLE
set metadata for article #102

### DIFF
--- a/client/pages/Articles/Show.js
+++ b/client/pages/Articles/Show.js
@@ -1,4 +1,5 @@
 import React from "react"
+import Helmet from "react-helmet"
 import { connect } from "react-redux"
 import Markdown from "markdown-to-jsx"
 import styled from "styled-components"
@@ -78,6 +79,10 @@ class Article extends React.Component {
           </BlockLink>
         </Column>
         <Column smOffset={1} sm={8}>
+          <Helmet>
+            <title>{title}</title>
+            <meta name="article-hero-image" content={photo.fields.file.url} />
+          </Helmet>
           <h1>{title}</h1>
           {photo && (
             <img


### PR DESCRIPTION
I used Helmet to set the title and image metadata for the articles. It looks like there are a few ways to do this and since I'm not sure I'm using the best method, I haven't made any changes with the videos. Could someone help me create unit tests for these tags?